### PR TITLE
fix: update build gradle to support libcrypto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ yarn-error.*
 # typescript
 *.tsbuildinfo
 package-lock.json
+yarn.lock

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -112,6 +112,13 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+    packagingOptions {
+        pickFirst 'lib/armeabi-v7a/libcrypto.so'
+        pickFirst 'lib/arm64-v8a/libcrypto.so'
+        pickFirst 'lib/x86_64/libcrypto.so'
+        pickFirst 'lib/x86/libcrypto.so'
+    }
+
 }
 
 // Apply static values from `gradle.properties` to the `android.packagingOptions`


### PR DESCRIPTION
In order to get this to build on my Pixel 5 I had to the `packagingOptions` to ensure it picks the right libcrypto path